### PR TITLE
German Fix

### DIFF
--- a/bin/i18n/German.ini
+++ b/bin/i18n/German.ini
@@ -1,5 +1,5 @@
 ; German
-; Deutsche Übersetzung von Matthias R.
+; Deutsche Übersetzung von Phoenix1747
 
 [i18n]
 IDS_UPDATE_NO=Es ist kein Update verfügbar.
@@ -11,7 +11,7 @@ IDS_EXIT=Beenden\tEsc
 IDS_HELP=Hilfe
 IDS_WEBSITE=Webseite
 IDS_DONATE=Spenden
-IDS_CHECKUPDATES=Nach updates prüfen
+IDS_CHECKUPDATES=Nach Updates suchen
 IDS_ABOUT=Über
 
 IDS_TRAY_SHOW=Anzeigen/Verstecken
@@ -53,7 +53,7 @@ IDS_LOADONSTARTUP_CHK=Beim Systemstart laden (Autostart)
 IDS_STARTMINIMIZED_CHK=Minimiert starten
 IDS_REDUCTCONFIRMATION_CHK=Speicherbereinigung bestätigen
 IDS_SKIPUACWARNING_CHK=Warnung der Benutzerkontensteuerung überspringen
-IDS_CHECKUPDATES_CHK=Regelmäßig nach Updates prüfen (empfohlen)
+IDS_CHECKUPDATES_CHK=Regelmäßig nach Updates suchen (empfohlen)
 
 IDS_LANGUAGE_HINT=Sprache auswählen:
 
@@ -92,7 +92,7 @@ IDS_TRAY_ACTION_3=Taskmanager öffnen
 
 IDS_SHOW_CLEAN_RESULT_CHK=Zeige Ergebnis der Speicherreinigung
 
-IDS_QUESTION=Mit der Speicherreinigung beginnen?
+IDS_QUESTION=Soll der Speicher wirklich bereinigt werden?
 
 IDS_TOOLTIP=Physisch: %d%%\r\nAuslagerungsdatei: %d%%\r\nSystemreserviert: %d%%
 

--- a/bin/i18n/German.ini
+++ b/bin/i18n/German.ini
@@ -1,9 +1,9 @@
 ; German
-; Deutsche Ãœbersetzung von Phoenix1747
+; Deutsche Übersetzung von Phoenix1747
 
 [i18n]
-IDS_UPDATE_NO=Es ist kein Update verfÃ¼gbar.
-IDS_UPDATE_YES=Die neue Version (%s) ist verfÃ¼gbar! Downloadseite Ã¶ffnen?
+IDS_UPDATE_NO=Es ist kein Update verfügbar.
+IDS_UPDATE_YES=Die neue Version (%s) ist verfügbar! Downloadseite öffnen?
 
 IDS_FILE=Datei
 IDS_SETTINGS=Einstellungen...
@@ -12,12 +12,12 @@ IDS_HELP=Hilfe
 IDS_WEBSITE=Webseite
 IDS_DONATE=Spenden
 IDS_CHECKUPDATES=Nach Updates suchen
-IDS_ABOUT=Ãœber
+IDS_ABOUT=Über
 
 IDS_TRAY_SHOW=Anzeigen/Verstecken
 IDS_TRAY_DISABLE=Deaktiviert
 IDS_TRAY_POPUP_1=Bereiche bereinigen
-IDS_TRAY_POPUP_2=SÃ¤ubern, wenn Ã¼ber
+IDS_TRAY_POPUP_2=Säubern, wenn über
 IDS_TRAY_POPUP_3=Bereinigungsintervall
 
 IDS_CLEAN=Speicher reinigen
@@ -27,7 +27,7 @@ IDS_GROUP_2=Ausgelagerte Dateien
 IDS_GROUP_3=Systemreserviert
 
 IDS_ITEM_1=In Verwendung
-IDS_ITEM_2=VerfÃ¼gbar
+IDS_ITEM_2=Verfügbar
 IDS_ITEM_3=Insgesamt
 
 IDS_SETTINGS_1=Allgemein
@@ -36,11 +36,11 @@ IDS_SETTINGS_3=Design
 IDS_SETTINGS_4=Taskleiste
 
 IDS_APPLY=Anwenden
-IDS_CLOSE=SchlieÃŸen
+IDS_CLOSE=Schließen
 
 IDS_TITLE_1=Allgemeine Einstellungen:
 IDS_TITLE_2=Sprache:
-IDS_TITLE_3=Zu sÃ¤ubernde Speicherbereiche:
+IDS_TITLE_3=Zu säubernde Speicherbereiche:
 IDS_TITLE_4=Speicherverwaltung:
 IDS_TITLE_5=Hotkeys (global):
 IDS_TITLE_6=Aussehen:
@@ -51,19 +51,19 @@ IDS_TITLE_9=Benachrichtigung:
 IDS_ALWAYSONTOP_CHK=Im Vordergrund bleiben
 IDS_LOADONSTARTUP_CHK=Beim Systemstart laden (Autostart)
 IDS_STARTMINIMIZED_CHK=Minimiert starten
-IDS_REDUCTCONFIRMATION_CHK=Speicherbereinigung bestÃ¤tigen
-IDS_SKIPUACWARNING_CHK=Warnung der Benutzerkontensteuerung Ã¼berspringen
-IDS_CHECKUPDATES_CHK=RegelmÃ¤ÃŸig nach Updates suchen (empfohlen)
+IDS_REDUCTCONFIRMATION_CHK=Speicherbereinigung bestätigen
+IDS_SKIPUACWARNING_CHK=Warnung der Benutzerkontensteuerung überspringen
+IDS_CHECKUPDATES_CHK=Regelmäßig nach Updates suchen (empfohlen)
 
-IDS_LANGUAGE_HINT=Sprache auswÃ¤hlen:
+IDS_LANGUAGE_HINT=Sprache auswählen:
 
 IDS_WORKINGSET_CHK=Benutzeranwendungen
 IDS_SYSTEMWORKINGSET_CHK=Systemanwendungen
-IDS_STANDBYLISTPRIORITY0_CHK=Standybyanwendungen ohne PrioritÃ¤t (Vista und hÃ¶her)
-IDS_STANDBYLIST_CHK=Standbyanwendungen (Vista und hÃ¶her)
-IDS_MODIFIEDLIST_CHK=Ausgelagerte Dateien (Vista und hÃ¶her)
+IDS_STANDBYLISTPRIORITY0_CHK=Standybyanwendungen ohne Priorität (Vista und höher)
+IDS_STANDBYLIST_CHK=Standbyanwendungen (Vista und höher)
+IDS_MODIFIEDLIST_CHK=Ausgelagerte Dateien (Vista und höher)
 
-IDS_AUTOREDUCTENABLE_CHK=SÃ¤ubern, wenn Ã¼ber: (%)
+IDS_AUTOREDUCTENABLE_CHK=Säubern, wenn über: (%)
 IDS_AUTOREDUCTINTERVALENABLE_CHK=Reinigungsintervall: (Min.)
 
 IDS_HOTKEY_CLEAN_CHK=Speicherreinigung:
@@ -71,7 +71,7 @@ IDS_HOTKEY_CLEAN_CHK=Speicherreinigung:
 IDS_TRAYUSETRANSPARENCY_CHK=Transparenter Hintergrund
 IDS_TRAYSHOWBORDER_CHK=Rahmen anzeigen
 IDS_TRAYROUNDCORNERS_CHK=Abgerundete Ecken
-IDS_TRAYCHANGEBG_CHK=Farbe der Schriftart Ã¤ndern (statt Text und Rahmen)
+IDS_TRAYCHANGEBG_CHK=Farbe der Schriftart ändern (statt Text und Rahmen)
 IDS_TRAYUSEANTIALIASING_CHK=Antialiasing verwenden
 
 IDS_FONT_HINT=Schriftart:
@@ -88,7 +88,7 @@ IDS_TRAYACTIONMC_HINT=Mittlere Maustaste:
 
 IDS_TRAY_ACTION_1=Verstecken/Anzeigen
 IDS_TRAY_ACTION_2=Speicher reinigen
-IDS_TRAY_ACTION_3=Taskmanager Ã¶ffnen
+IDS_TRAY_ACTION_3=Taskmanager öffnen
 
 IDS_SHOW_CLEAN_RESULT_CHK=Zeige Ergebnis der Speicherreinigung
 
@@ -97,4 +97,4 @@ IDS_QUESTION=Soll der Speicher wirklich bereinigt werden?
 IDS_TOOLTIP=Physisch: %d%%\r\nAuslagerungsdatei: %d%%\r\nSystemreserviert: %d%%
 
 IDS_STATUS_CLEANED=Der Speicher wurde zu %s bereinigt.
-IDS_STATUS_NOPRIVILEGES=Dieses Programm benÃ¶tigt Administratorrechte, bitte fÃ¼hren Sie dieses Programm als Administrator aus!
+IDS_STATUS_NOPRIVILEGES=Dieses Programm benötigt Administratorrechte, bitte führen Sie dieses Programm als Administrator aus!


### PR DESCRIPTION
So since the recent update came out, I had a look at the German translation I did some time ago. Unfortunately the ini file was coded in UTF-8 which happens to not work with the program itself and some German letters (ä,ö,ü,ß).

I had a look at this and it seems to be fixed with ANSI coding. Additionally, I had a look at the translation itself and fixed some minor mistakes.