### PR TITLE
Fix inability to change color after black color is set

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1170,16 +1170,13 @@ INT_PTR CALLBACK SettingsProc (
 
 					clr = (COLORREF)_r_listview_getitemlparam (hwnd, listview_id, lpnmlv->iItem);
 
-					if (!clr)
-						break;
-
 					cc.lStructSize = sizeof (CHOOSECOLOR);
 					cc.Flags = CC_RGBINIT | CC_FULLOPEN;
 					cc.hwndOwner = hwnd;
 					cc.lpCustColors = cust;
 					cc.rgbResult = clr;
 
-					if (ChooseColorW (&cc))
+					if (ChooseColorW (&cc) && clr != cc.rgbResult)
 					{
 						if (lpnmlv->iItem == 0)
 						{


### PR DESCRIPTION
In codehere is check for NULL(0) of COLORREF, but it CAN be 0 since it's an A,R,G,B components, packed into Int32

So to fix issue, this check was simply removed
Additionally check for value change was added to prevent useless updates when nothing was actually changed