### PR TITLE
Fix of ListView items dupe on settings reset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -830,6 +830,8 @@ INT_PTR CALLBACK SettingsProc (
 
 					_r_wnd_setcontext (hwnd, IDC_REGIONS, INVALID_HANDLE_VALUE);
 
+					_r_listview_reset (hwnd, IDC_REGIONS);
+
 					_r_listview_addcolumn (hwnd, IDC_REGIONS, 0, L"", 10, LVCFMT_LEFT);
 
 					_r_listview_additem (hwnd, IDC_REGIONS, 0, TITLE_WORKINGSET, I_DEFAULT, I_DEFAULT, REDUCT_WORKING_SET);
@@ -905,6 +907,8 @@ INT_PTR CALLBACK SettingsProc (
 					_app_setfontcontrol (hwnd, IDC_FONT, &logfont, dpi_value);
 
 					_r_listview_setstyle (hwnd, IDC_COLORS, LVS_EX_DOUBLEBUFFER | LVS_EX_FULLROWSELECT | LVS_EX_INFOTIP | LVS_EX_LABELTIP, FALSE);
+
+					_r_listview_reset(hwnd, IDC_COLORS);
 
 					_r_listview_addcolumn (hwnd, IDC_COLORS, 0, L"", -100, LVCFMT_LEFT);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1170,16 +1170,13 @@ INT_PTR CALLBACK SettingsProc (
 
 					clr = (COLORREF)_r_listview_getitemlparam (hwnd, listview_id, lpnmlv->iItem);
 
-					if (!clr)
-						break;
-
 					cc.lStructSize = sizeof (CHOOSECOLOR);
 					cc.Flags = CC_RGBINIT | CC_FULLOPEN;
 					cc.hwndOwner = hwnd;
 					cc.lpCustColors = cust;
 					cc.rgbResult = clr;
 
-					if (ChooseColorW (&cc))
+					if (ChooseColorW (&cc) && clr != cc.rgbResult)
 					{
 						if (lpnmlv->iItem == 0)
 						{


### PR DESCRIPTION
When settings resets, items in all listviews(and probably any other container-like controls, used to change actual settings) are duped.

Here is a simple fix - listview reset. Note that this fix require 3e8b35b2 (henrypp/routine#13)

this is a cumulative PR, includes #269