### PR TITLE
[Feature] Ability to display transparent tray icon

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -830,6 +830,8 @@ INT_PTR CALLBACK SettingsProc (
 
 					_r_wnd_setcontext (hwnd, IDC_REGIONS, INVALID_HANDLE_VALUE);
 
+					_r_listview_reset (hwnd, IDC_REGIONS);
+
 					_r_listview_addcolumn (hwnd, IDC_REGIONS, 0, L"", 10, LVCFMT_LEFT);
 
 					_r_listview_additem (hwnd, IDC_REGIONS, 0, TITLE_WORKINGSET, I_DEFAULT, I_DEFAULT, REDUCT_WORKING_SET);
@@ -905,6 +907,8 @@ INT_PTR CALLBACK SettingsProc (
 					_app_setfontcontrol (hwnd, IDC_FONT, &logfont, dpi_value);
 
 					_r_listview_setstyle (hwnd, IDC_COLORS, LVS_EX_DOUBLEBUFFER | LVS_EX_FULLROWSELECT | LVS_EX_INFOTIP | LVS_EX_LABELTIP, FALSE);
+
+					_r_listview_reset(hwnd, IDC_COLORS);
 
 					_r_listview_addcolumn (hwnd, IDC_COLORS, 0, L"", -100, LVCFMT_LEFT);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1170,16 +1170,13 @@ INT_PTR CALLBACK SettingsProc (
 
 					clr = (COLORREF)_r_listview_getitemlparam (hwnd, listview_id, lpnmlv->iItem);
 
-					if (!clr)
-						break;
-
 					cc.lStructSize = sizeof (CHOOSECOLOR);
 					cc.Flags = CC_RGBINIT | CC_FULLOPEN;
 					cc.hwndOwner = hwnd;
 					cc.lpCustColors = cust;
 					cc.rgbResult = clr;
 
-					if (ChooseColorW (&cc))
+					if (ChooseColorW (&cc) && clr != cc.rgbResult)
 					{
 						if (lpnmlv->iItem == 0)
 						{

--- a/src/main.h
+++ b/src/main.h
@@ -61,7 +61,11 @@ typedef struct _STATIC_DATA
 	HDC hdc;
 	HDC hdc_mask;
 	HBITMAP hbitmap;
+	HBITMAP hbitmap_alpha;
 	HBITMAP hbitmap_mask;
+	PDWORD dwbits_icon_argb;
+	PDWORD dwbits_icon_bw;
+	LONG dwbits_icon_length;
 	HFONT hfont;
 	RECT icon_size;
 	ULONG ms_prev;


### PR DESCRIPTION
As noted in #229, when transparent background is enabled, text become jagged (aliased) and this happens due to 1bit mask.
However, since WinXP ([docs; 2nd approach; comments](https://learn.microsoft.com/windows/win32/menurc/using-cursors)) tray icons supports transparency(alpha/32bit), so it's possible to solve this issue

There some complications and troubles with using GDI and ClearType(especially ClearType - it's additive and subpixel-alpha-ed)
But here is possible solution: calculating of additive alpha and applying it to bitmap manually

Note: this is not perfect solution because calculated alpha is additive, which is not what actual alpha blending expects.

Note: i'm continue to use `BITMAPINFOHEADER` because ARGB is a default order; if you wish you can switch to `BITMAPV5HEADER` and init bitmap according to docs (that was initial implementation, so rest of the code would works as is)

This is a cumulative PR, includes #269 #270